### PR TITLE
maOS like file paths, better watchfile to detect WiFi changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ additional actions when changing the Location.
 ## Installation & Updates
 
 ```
-curl -L https://github.com/sashagavrilov/locationchanger/raw/master/locationchanger.sh | bash
+curl -L https://github.com/lisanet/locationchanger/raw/master/locationchanger.sh | bash
 ```
 
 You must be an Administrator to install *Location Changer* and it will ask you for your password.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ When joining a Wi-Fi network, *Location Changer* will look for a Location whose 
 SSID and will switch accordingly.
 
 If *Location Changer* is unable to find a Location name matching the SSID, it will default to 'Automatic'.
-The default Location name can be changed by editing the `DEFAULT_LOCATION` variable (on Line 15) prior to installation.
+The default Location name can be changed by editing the `DEFAULT_LOCATION` variable in the config file.
 
 
 ## Advanced Usage
@@ -52,13 +52,20 @@ configure the same Location to be used with both.
 *Location Changer* can also be disabled for certain locations. This is usefull, e.g., if you want 
 to set Location manually and don't want it to be automatically changed back.
 
-Configuration happens in `${HOME}/.locations/locations.conf` by default. The location of this file can be changed
-by editing the `CONFIG_FILE` variable (on Line 17) in the `locationchanger.sh` script prior to installation. It should be a ini-format
-file with two sections:  `Automatic` and `Manual`. 
-`Automatic` section defines mapping for Wi-Fi Network SSIDs as key-value pairs in the following format. 
+Configuration happens in `${HOME}/Library/Application Support/LocationChanger/LocationChanger.conf` by default. 
+On installation a default config file is generated.
+The config file is in ini-format and contains trhe sections: `General` , `Automatic` and `Manual`. 
+
+The `General` defines two configurable variables. 
+DEFAULT_LOCATION specifies the Location to use, if the current WiFi is not configured explicitly. The default is 'Automatic'
+ENABLE_NOTIFICATIONS spec ifies the notification behaviour. Set it to 1 to enable notifications. For verbose notifications, 
+set to 2. To disable, set to 0.
+
+The `Automatic` section defines mapping for Wi-Fi Network SSIDs as key-value pairs in the following format. 
 Spaces are supported for both the SSID as well as the Location name, but all spaces around the `=` will be trimmed.
 Additionally, do not enclose the SSID or Location in quotes.
-`Manual` section contains list of Location names for wich autodetection should be ignored.
+
+The `Manual` section contains a list of Location names for wich autodetection should be ignored.
 
 ```bash
 [Automatic]
@@ -76,14 +83,14 @@ Wi-Fi Only
 *Location Changer* includes support for running custom scripts when switching Locations. Scripts
 should be:
 
-* installed into the `SCRIPT_DIR` directory (`${HOME}/.locations/` by default)
+* installed into the directory `${HOME}/Library/Application Support/LocationChanger` 
 * named identically to the Location (e.g. `Home Wi-Fi` and not `Home Wi-Fi.sh`; if using manually configured Locations, please ensure the name matches the Location and not the SSID)
 * be executable
 
 
 #### Examples
 
-You may want to set your computer to require a password to unlock while at work. By creating a script that matches the work Location name (e.g. `${HOME}/.locations/Work`), this script can perform that configuration automatically when changing to the `Work` Location.
+You may want to set your computer to require a password to unlock while at work. By creating a script that matches the work Location name (e.g. `${HOME}/Library/Application Support/LocationChanger/Work`), this script can perform that configuration automatically when changing to the `Work` Location.
 
 ```bash
 #!/usr/bin/env bash
@@ -93,7 +100,7 @@ exec 2>&1
 osascript -e 'tell application "System Events" to set require password to wake of security preferences to true'
 ```
 
-You may also want to create a script that reverses those changes when you're at home, so you don't have to enter your password to unlock your computer. You can save this as `${HOME}/.locations/Home` if your home's SSID is `Home` or you have manually configured the `Home` Location to be used for your home's Wi-Fi SSID. Alternatively, it could be saved to your default Location (`Automatic`, by default) if using the default location at home: `${HOME}/.locations/Automatic`
+You may also want to create a script that reverses those changes when you're at home, so you don't have to enter your password to unlock your computer. You can save this as `${HOME}/Library/Application Support/LocationChanger/Home` if your home's SSID is `Home` or you have manually configured the `Home` Location to be used for your home's Wi-Fi SSID. Alternatively, it could be saved to your default Location (`Automatic`, by default) if using the default location at home: `${HOME}/Library/Application Support/LocationChanger/Automatic`
 
 ```bash
 #!/usr/bin/env bash
@@ -105,7 +112,7 @@ osascript -e 'tell application "System Events" to set require password to wake o
 
 ### Notifications
 
-*Location Changer* includes support for notifications through the macOS Notification system (via the AppleScript/osascript interface). By default, *Location Changer* will display a notification whenever the Location is changed. This behavior can be changed by editing the `ENABLE_NOTIFICATIONS` variable (on Line 16) in the script prior to installation. The following values are accepted:
+*Location Changer* includes support for notifications through the macOS Notification system (via the AppleScript/osascript interface). By default, *Location Changer* will display a notification whenever the Location is changed. This behavior can be changed by editing the `ENABLE_NOTIFICATIONS` variable in the config file. The following values are accepted:
 
 * `0` - disable notifications
 * `1` - enable notifications whenever the Location is changed
@@ -113,7 +120,7 @@ osascript -e 'tell application "System Events" to set require password to wake o
 
 ## Troubleshooting
 
-Logging information is written to `${HOME}/Library/Logs/LocationChanger.log` by default. This can be adjusted by editing the `LOGFILE` variable (on Line 21) in the script prior to installation. Inspecting this log can be helpful when troubleshooting issues.
+Logging information is written to `${HOME}/Library/Logs/LocationChanger.log` by default. Inspecting this log can be helpful when troubleshooting issues.
 
 ```bash
 tail -f ~/Library/Logs/LocationChanger.log
@@ -125,6 +132,6 @@ Sample output:
 [2018-03-05 06:23:18] Connected to 'Home Wi-Fi'
 [2018-03-05 06:23:18] Will switch the Location to 'DHCP' (found in configuration file)
 [2018-03-05 06:23:18] Changing the Location to 'DHCP'
-CurrentSet updated to 3BA418DE-3C72-2EAB-A8A6-B71C42189204 (DHCP)
+[2018-03-05 06:23:18] CurrentSet updated to 3BA418DE-3C72-2EAB-A8A6-B71C42189204 (DHCP)
 [2018-03-05 06:23:19] Running script: '/Users/username/.locations/DHCP'
 ```

--- a/locationchanger.sh
+++ b/locationchanger.sh
@@ -13,7 +13,7 @@ cat << "EOT" | sudo tee ${SCRIPT_NAME} > /dev/null
 
 # This script changes network Location based on the name of Wi-Fi network.
 DEFAULT_LOCATION='Automatic'
-ENABLE_NOTIFICATIONS=1 # To enable notifications, set to 1. For verbose notifications, set to 2. To disable, set to 0.
+ENABLE_NOTIFICATIONS=1
 CONFIG_FILE="$HOME/Library/Application Support/LocationChanger/LocationChanger.conf"
 SCRIPT_DIR="$HOME/Library/Application Support/LocationChanger" # directory for scripts attached to Locations
 LOGFILE=${HOME}/Library/Logs/LocationChanger.log
@@ -49,6 +49,18 @@ fi
 
 ts "Connected to '${SSID}'"
 
+# read some default variables from config file, if they exist
+if [ -e "${CONFIG_FILE}" ]; then
+    VALUE=$(parse_config General | grep ENABLE_NOTIFICATIONS= | cut -d = -f 2)
+    if [ "$VALUE" != "" ]; then
+        ENABLE_NOTIFICATIONS=$VALUE
+    fi
+    VALUE=$(parse_config General | grep DEFAULT_LOCATION= | cut -d = -f 2)
+    if [ "$VALUE" != "" ]; then
+        DEFAULT_LOCATION="$VALUE"
+    fi
+fi
+
 # escape the SSID string for better string handling in our logic below
 ESSID=$(echo "${SSID}" | sed 's/[.[\*^$]/\\\\&/g')
 
@@ -81,7 +93,7 @@ if [ -z "${NEW_LOCATION}"] && echo "${LOCATION_NAMES}" | grep -q "^${ESSID}$"; t
     ts "Location '${SSID}' was found and matches the SSID. Will switch the Location to '${NEW_LOCATION}'"
 # if still not found, try to use the DEFAULT_LOCATION
 elif [ -z "${NEW_LOCATION}"] && echo "${LOCATION_NAMES}" | grep -q "^${DEFAULT_LOCATION}$"; then
-    NEW_LOCATION=${DEFAULT_LOCATION}
+    NEW_LOCATION="${DEFAULT_LOCATION}"
     NOTIFICATION_STRING="Changing from '${CURRENT_LOCATION}' to default Location '${DEFAULT_LOCATION}'"
     ts "Location '${SSID}' was not found. Will default to '${DEFAULT_LOCATION}'"
 # if we arrived here, something went awry
@@ -124,6 +136,31 @@ exit 0
 EOT
 
 sudo chmod +x ${SCRIPT_NAME}
+
+# generate a default config file if it doesn't exists
+APP_SUPPORT_DIR="$HOME/Library/Application Support/LocationChanger"
+if [ ! -e "${APP_SUPPORT_DIR}/LocationChanger.conf" ]; then
+mkdir -p "${APP_SUPPORT_DIR}"
+cat > "$APP_SUPPORT_DIR/LocationChanger.conf" << EOT
+[General]
+# specify the default Location to use. The default is 'Automatic'
+#DEFAULT_LOCATION=Automatic
+# To enable notifications, set to 1. For verbose notifications, set to 2. To disable, set to 0.
+#ENABLE_NOTIFICATIONS=1
+
+[Automatic]
+# [Automatic] defines a mapping for Wi-Fi Network SSIDs to Location names as key-value pairs.
+# Spaces are supported for both the SSID as well as the Location name, but all spaces
+# around the '=' will be trimmed. Additionally, do not enclose the SSID or Location in quotes
+# SSID=Location name
+
+[Manual]
+# This section contains a list of Location names for which autodetection and Location
+# switching should be ignored.
+# Wi-Fi Only
+
+EOT
+fi
 
 mkdir -p ${LAUNCH_AGENTS_DIR}
 cat > ${PLIST_NAME} << EOT

--- a/locationchanger.sh
+++ b/locationchanger.sh
@@ -14,8 +14,8 @@ cat << "EOT" | sudo tee ${SCRIPT_NAME} > /dev/null
 # This script changes network Location based on the name of Wi-Fi network.
 DEFAULT_LOCATION='Automatic'
 ENABLE_NOTIFICATIONS=1 # To enable notifications, set to 1. For verbose notifications, set to 2. To disable, set to 0.
-CONFIG_FILE=${HOME}/.locations/locations.conf
-SCRIPT_DIR=${HOME}/.locations # directory for scripts attached to Locations
+CONFIG_FILE="$HOME/Library/Application Support/LocationChanger/LocationChanger.conf"
+SCRIPT_DIR="$HOME/Library/Application Support/LocationChanger" # directory for scripts attached to Locations
 LOGFILE=${HOME}/Library/Logs/LocationChanger.log
 
 exec 2>&1 >> ${LOGFILE}
@@ -31,7 +31,7 @@ parse_config() {
                                                  -e 's/[;#].*$//'       \
                                                  -e 's/[[:space:]]*$//' \
                                                  -e 's/^[[:space:]]*//' \
-                                         <  ${CONFIG_FILE}              \
+                                         <  "${CONFIG_FILE}"              \
                                          | sed  -n -e "/^\[$1\]/,/^s*\[/{/^[^;[]/p;}")
     echo "${myresult}"
 }
@@ -53,7 +53,7 @@ ts "Connected to '${SSID}'"
 ESSID=$(echo "${SSID}" | sed 's/[.[\*^$]/\\\\&/g')
 
 # if a config file exists, consult it first
-if [ -f ${CONFIG_FILE} ]; then
+if [ -f "${CONFIG_FILE}" ]; then
     # check if the current location is marked as manual (no autodetection required)
     if echo "$(parse_config Manual)" | grep -q "^${CURRENT_LOCATION}$" ; then
         NEW_LOCATION=${CURRENT_LOCATION}

--- a/locationchanger.sh
+++ b/locationchanger.sh
@@ -18,6 +18,15 @@ CONFIG_FILE="$HOME/Library/Application Support/LocationChanger/LocationChanger.c
 SCRIPT_DIR="$HOME/Library/Application Support/LocationChanger" # directory for scripts attached to Locations
 LOGFILE=${HOME}/Library/Logs/LocationChanger.log
 
+# truncate logfile
+lines=$(cat "$LOGFILE" | wc -l)
+if [ $lines -gt 300 ]; then
+    temp=$(mktemp)
+    tail -n +200 "$LOGFILE" > "$temp"
+    rm "$LOGFILE"
+    mv "$temp" "$LOGFILE"
+fi
+
 exec 2>&1 >> ${LOGFILE}
 
 sleep 3

--- a/locationchanger.sh
+++ b/locationchanger.sh
@@ -106,7 +106,7 @@ fi
 if [ "${NEW_LOCATION}" != "" ]; then
     if [ "${NEW_LOCATION}" != "${CURRENT_LOCATION}" ]; then
         ts "Changing the Location to '${NEW_LOCATION}'"
-        scselect "${NEW_LOCATION}"
+        ts $(scselect "${NEW_LOCATION}")
         if [ ${?} -ne 0 ]; then
             NOTIFICATION_STRING="Something went wrong trying to automatically switch Location. Please consult the log at: ${LOGFILE}"
         fi

--- a/locationchanger.sh
+++ b/locationchanger.sh
@@ -129,7 +129,7 @@ fi
 
 # if notifications are enabled, let 'em know what's happenin'!
 if [ ${ENABLE_NOTIFICATIONS} -ge 1 ]; then
-    osascript -e "display notification \"${NOTIFICATION_STRING}\" with title \"locationchanger\""
+    osascript -e "display notification \"${NOTIFICATION_STRING}\" with title \"LocationChanger\""
 fi
 
 exit 0

--- a/locationchanger.sh
+++ b/locationchanger.sh
@@ -176,7 +176,7 @@ cat > ${PLIST_NAME} << EOT
     </array>
     <key>WatchPaths</key>
     <array>
-        <string>/Library/Preferences/SystemConfiguration/com.apple.airport.preferences.plist</string>
+        <string>/Library/Preferences/SystemConfiguration/com.apple.wifi.message-tracer.plist</string>
     </array>
 </dict>
 </plist>

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+INSTALL_DIR=/usr/local/bin
+SCRIPT_NAME=$INSTALL_DIR/locationchanger
+LAUNCH_AGENTS_DIR=$HOME/Library/LaunchAgents
+PLIST_NAME=$LAUNCH_AGENTS_DIR/LocationChanger.plist
+
+echo "This will uninstall LocationChanger and its config files and scripts from your Mac.\n"
+echo "Are you sure to uninstall LocationCahnger (y/n)?"
+read reply
+if [ "$reply" != "y" ]; then
+    echo "Aborting uninstall command."
+    exit
+fi
+
+sudo rm "$SCRIPT_NAME"
+launchctl unload "$PLIST_NAME"
+rm "$PLIST_NAME"
+rm -rf "$HOME/Library/Application Support/LocationChanger"
+rm -rf "${HOME}/Library/Logs/LocationChanger.log"
+
+echo "Uninstall complete."


### PR DESCRIPTION
This pull request uses a more macOS like path for the config and script files and it moves all remaining  configurable options to the config file.

There's also a new file to watch, so that it's possible to detect changing a WiFi network which the user doesn't want do be remembered.

A uninstall script and a few minor patches  are included too (spelling, timestamp to scselect output, restrict size of log file) 